### PR TITLE
JBTM-3812  use the correct SPDX license id text

### DIFF
--- a/src/main/java/org/jboss/tm/ConnectableResource.java
+++ b/src/main/java/org/jboss/tm/ConnectableResource.java
@@ -1,6 +1,6 @@
 /*
    Copyright The Narayana Authors
-   SPDX short identifier: Apache-2.0
+   SPDX-License-Identifier: Apache-2.0
  */
 package org.jboss.tm;
 

--- a/src/main/java/org/jboss/tm/ExtendedJBossXATerminator.java
+++ b/src/main/java/org/jboss/tm/ExtendedJBossXATerminator.java
@@ -1,6 +1,6 @@
 /*
    Copyright The Narayana Authors
-   SPDX short identifier: Apache-2.0
+   SPDX-License-Identifier: Apache-2.0
  */
 package org.jboss.tm;
 

--- a/src/main/java/org/jboss/tm/FirstResource.java
+++ b/src/main/java/org/jboss/tm/FirstResource.java
@@ -1,6 +1,6 @@
 /*
    Copyright The Narayana Authors
-   SPDX short identifier: Apache-2.0
+   SPDX-License-Identifier: Apache-2.0
  */
 package org.jboss.tm;
 

--- a/src/main/java/org/jboss/tm/ImportedTransaction.java
+++ b/src/main/java/org/jboss/tm/ImportedTransaction.java
@@ -1,6 +1,6 @@
 /*
    Copyright The Narayana Authors
-   SPDX short identifier: Apache-2.0
+   SPDX-License-Identifier: Apache-2.0
  */
 package org.jboss.tm;
 

--- a/src/main/java/org/jboss/tm/JBossXATerminator.java
+++ b/src/main/java/org/jboss/tm/JBossXATerminator.java
@@ -1,6 +1,6 @@
 /*
    Copyright The Narayana Authors
-   SPDX short identifier: Apache-2.0
+   SPDX-License-Identifier: Apache-2.0
  */
 package org.jboss.tm;
 

--- a/src/main/java/org/jboss/tm/LastResource.java
+++ b/src/main/java/org/jboss/tm/LastResource.java
@@ -1,6 +1,6 @@
 /*
    Copyright The Narayana Authors
-   SPDX short identifier: Apache-2.0
+   SPDX-License-Identifier: Apache-2.0
  */
 package org.jboss.tm;
 

--- a/src/main/java/org/jboss/tm/TransactionImportResult.java
+++ b/src/main/java/org/jboss/tm/TransactionImportResult.java
@@ -1,6 +1,6 @@
 /*
    Copyright The Narayana Authors
-   SPDX short identifier: Apache-2.0
+   SPDX-License-Identifier: Apache-2.0
  */
 package org.jboss.tm;
 

--- a/src/main/java/org/jboss/tm/TransactionLocal.java
+++ b/src/main/java/org/jboss/tm/TransactionLocal.java
@@ -1,6 +1,6 @@
 /*
    Copyright The Narayana Authors
-   SPDX short identifier: Apache-2.0
+   SPDX-License-Identifier: Apache-2.0
  */
 package org.jboss.tm;
 

--- a/src/main/java/org/jboss/tm/TransactionLocalDelegate.java
+++ b/src/main/java/org/jboss/tm/TransactionLocalDelegate.java
@@ -1,6 +1,6 @@
 /*
    Copyright The Narayana Authors
-   SPDX short identifier: Apache-2.0
+   SPDX-License-Identifier: Apache-2.0
  */
 package org.jboss.tm;
 

--- a/src/main/java/org/jboss/tm/TransactionLocalDelegateImpl.java
+++ b/src/main/java/org/jboss/tm/TransactionLocalDelegateImpl.java
@@ -1,6 +1,6 @@
 /*
    Copyright The Narayana Authors
-   SPDX short identifier: Apache-2.0
+   SPDX-License-Identifier: Apache-2.0
  */
 package org.jboss.tm;
 

--- a/src/main/java/org/jboss/tm/TransactionManagerFactory.java
+++ b/src/main/java/org/jboss/tm/TransactionManagerFactory.java
@@ -1,6 +1,6 @@
 /*
    Copyright The Narayana Authors
-   SPDX short identifier: Apache-2.0
+   SPDX-License-Identifier: Apache-2.0
  */
 package org.jboss.tm;
 

--- a/src/main/java/org/jboss/tm/TransactionManagerLocator.java
+++ b/src/main/java/org/jboss/tm/TransactionManagerLocator.java
@@ -1,6 +1,6 @@
 /*
    Copyright The Narayana Authors
-   SPDX short identifier: Apache-2.0
+   SPDX-License-Identifier: Apache-2.0
  */
 package org.jboss.tm;
 

--- a/src/main/java/org/jboss/tm/TransactionPropagationContextFactory.java
+++ b/src/main/java/org/jboss/tm/TransactionPropagationContextFactory.java
@@ -1,6 +1,6 @@
 /*
    Copyright The Narayana Authors
-   SPDX short identifier: Apache-2.0
+   SPDX-License-Identifier: Apache-2.0
  */
 package org.jboss.tm;
 

--- a/src/main/java/org/jboss/tm/TransactionPropagationContextImporter.java
+++ b/src/main/java/org/jboss/tm/TransactionPropagationContextImporter.java
@@ -1,6 +1,6 @@
 /*
    Copyright The Narayana Authors
-   SPDX short identifier: Apache-2.0
+   SPDX-License-Identifier: Apache-2.0
  */
 package org.jboss.tm;
 

--- a/src/main/java/org/jboss/tm/TransactionPropagationContextUtil.java
+++ b/src/main/java/org/jboss/tm/TransactionPropagationContextUtil.java
@@ -1,6 +1,6 @@
 /*
    Copyright The Narayana Authors
-   SPDX short identifier: Apache-2.0
+   SPDX-License-Identifier: Apache-2.0
  */
 package org.jboss.tm;
 

--- a/src/main/java/org/jboss/tm/TransactionTimeoutConfiguration.java
+++ b/src/main/java/org/jboss/tm/TransactionTimeoutConfiguration.java
@@ -1,6 +1,6 @@
 /*
    Copyright The Narayana Authors
-   SPDX short identifier: Apache-2.0
+   SPDX-License-Identifier: Apache-2.0
  */
 package org.jboss.tm;
 

--- a/src/main/java/org/jboss/tm/TxUtils.java
+++ b/src/main/java/org/jboss/tm/TxUtils.java
@@ -1,6 +1,6 @@
 /*
    Copyright The Narayana Authors
-   SPDX short identifier: Apache-2.0
+   SPDX-License-Identifier: Apache-2.0
  */
 package org.jboss.tm;
 

--- a/src/main/java/org/jboss/tm/XAExceptionFormatter.java
+++ b/src/main/java/org/jboss/tm/XAExceptionFormatter.java
@@ -1,6 +1,6 @@
 /*
    Copyright The Narayana Authors
-   SPDX short identifier: Apache-2.0
+   SPDX-License-Identifier: Apache-2.0
  */
 package org.jboss.tm;
 

--- a/src/main/java/org/jboss/tm/XAResourceRecovery.java
+++ b/src/main/java/org/jboss/tm/XAResourceRecovery.java
@@ -1,6 +1,6 @@
 /*
    Copyright The Narayana Authors
-   SPDX short identifier: Apache-2.0
+   SPDX-License-Identifier: Apache-2.0
  */
 package org.jboss.tm;
 

--- a/src/main/java/org/jboss/tm/XAResourceRecoveryRegistry.java
+++ b/src/main/java/org/jboss/tm/XAResourceRecoveryRegistry.java
@@ -1,6 +1,6 @@
 /*
    Copyright The Narayana Authors
-   SPDX short identifier: Apache-2.0
+   SPDX-License-Identifier: Apache-2.0
  */
 package org.jboss.tm;
 

--- a/src/main/java/org/jboss/tm/XAResourceWrapper.java
+++ b/src/main/java/org/jboss/tm/XAResourceWrapper.java
@@ -1,6 +1,6 @@
 /*
    Copyright The Narayana Authors
-   SPDX short identifier: Apache-2.0
+   SPDX-License-Identifier: Apache-2.0
  */
 package org.jboss.tm;
 

--- a/src/main/java/org/jboss/tm/listener/EventType.java
+++ b/src/main/java/org/jboss/tm/listener/EventType.java
@@ -1,6 +1,6 @@
 /*
    Copyright The Narayana Authors
-   SPDX short identifier: Apache-2.0
+   SPDX-License-Identifier: Apache-2.0
  */
 package org.jboss.tm.listener;
 

--- a/src/main/java/org/jboss/tm/listener/TransactionEvent.java
+++ b/src/main/java/org/jboss/tm/listener/TransactionEvent.java
@@ -1,6 +1,6 @@
 /*
    Copyright The Narayana Authors
-   SPDX short identifier: Apache-2.0
+   SPDX-License-Identifier: Apache-2.0
  */
 package org.jboss.tm.listener;
 

--- a/src/main/java/org/jboss/tm/listener/TransactionListener.java
+++ b/src/main/java/org/jboss/tm/listener/TransactionListener.java
@@ -1,6 +1,6 @@
 /*
    Copyright The Narayana Authors
-   SPDX short identifier: Apache-2.0
+   SPDX-License-Identifier: Apache-2.0
  */
 package org.jboss.tm.listener;
 

--- a/src/main/java/org/jboss/tm/listener/TransactionListenerRegistry.java
+++ b/src/main/java/org/jboss/tm/listener/TransactionListenerRegistry.java
@@ -1,6 +1,6 @@
 /*
    Copyright The Narayana Authors
-   SPDX short identifier: Apache-2.0
+   SPDX-License-Identifier: Apache-2.0
  */
 package org.jboss.tm.listener;
 

--- a/src/main/java/org/jboss/tm/listener/TransactionListenerRegistryLocator.java
+++ b/src/main/java/org/jboss/tm/listener/TransactionListenerRegistryLocator.java
@@ -1,6 +1,6 @@
 /*
    Copyright The Narayana Authors
-   SPDX short identifier: Apache-2.0
+   SPDX-License-Identifier: Apache-2.0
  */
 package org.jboss.tm.listener;
 

--- a/src/main/java/org/jboss/tm/listener/TransactionListenerRegistryUnavailableException.java
+++ b/src/main/java/org/jboss/tm/listener/TransactionListenerRegistryUnavailableException.java
@@ -1,6 +1,6 @@
 /*
    Copyright The Narayana Authors
-   SPDX short identifier: Apache-2.0
+   SPDX-License-Identifier: Apache-2.0
  */
 package org.jboss.tm.listener;
 

--- a/src/main/java/org/jboss/tm/listener/TransactionTypeNotSupported.java
+++ b/src/main/java/org/jboss/tm/listener/TransactionTypeNotSupported.java
@@ -1,6 +1,6 @@
 /*
    Copyright The Narayana Authors
-   SPDX short identifier: Apache-2.0
+   SPDX-License-Identifier: Apache-2.0
  */
 package org.jboss.tm.listener;
 

--- a/src/main/java/org/jboss/tm/usertx/UserTransactionListener.java
+++ b/src/main/java/org/jboss/tm/usertx/UserTransactionListener.java
@@ -1,6 +1,6 @@
 /*
    Copyright The Narayana Authors
-   SPDX short identifier: Apache-2.0
+   SPDX-License-Identifier: Apache-2.0
  */
 package org.jboss.tm.usertx;
 

--- a/src/main/java/org/jboss/tm/usertx/UserTransactionOperationsProvider.java
+++ b/src/main/java/org/jboss/tm/usertx/UserTransactionOperationsProvider.java
@@ -1,6 +1,6 @@
 /*
    Copyright The Narayana Authors
-   SPDX short identifier: Apache-2.0
+   SPDX-License-Identifier: Apache-2.0
  */
 package org.jboss.tm.usertx;
 

--- a/src/main/java/org/jboss/tm/usertx/UserTransactionProvider.java
+++ b/src/main/java/org/jboss/tm/usertx/UserTransactionProvider.java
@@ -1,6 +1,6 @@
 /*
    Copyright The Narayana Authors
-   SPDX short identifier: Apache-2.0
+   SPDX-License-Identifier: Apache-2.0
  */
 package org.jboss.tm.usertx;
 

--- a/src/main/java/org/jboss/tm/usertx/UserTransactionRegistry.java
+++ b/src/main/java/org/jboss/tm/usertx/UserTransactionRegistry.java
@@ -1,6 +1,6 @@
 /*
    Copyright The Narayana Authors
-   SPDX short identifier: Apache-2.0
+   SPDX-License-Identifier: Apache-2.0
  */
 package org.jboss.tm.usertx;
 

--- a/src/main/java/org/jboss/tm/usertx/client/ServerVMClientUserTransaction.java
+++ b/src/main/java/org/jboss/tm/usertx/client/ServerVMClientUserTransaction.java
@@ -1,6 +1,6 @@
 /*
    Copyright The Narayana Authors
-   SPDX short identifier: Apache-2.0
+   SPDX-License-Identifier: Apache-2.0
  */
 package org.jboss.tm.usertx.client;
 

--- a/src/main/java/org/jboss/tm/usertx/client/ServerVMClientUserTransactionFactory.java
+++ b/src/main/java/org/jboss/tm/usertx/client/ServerVMClientUserTransactionFactory.java
@@ -1,6 +1,6 @@
 /*
    Copyright The Narayana Authors
-   SPDX short identifier: Apache-2.0
+   SPDX-License-Identifier: Apache-2.0
  */
 package org.jboss.tm.usertx.client;
 

--- a/src/main/java/org/jboss/tm/usertx/client/ServerVMClientUserTransactionOperationsProvider.java
+++ b/src/main/java/org/jboss/tm/usertx/client/ServerVMClientUserTransactionOperationsProvider.java
@@ -1,6 +1,6 @@
 /*
    Copyright The Narayana Authors
-   SPDX short identifier: Apache-2.0
+   SPDX-License-Identifier: Apache-2.0
  */
 package org.jboss.tm.usertx.client;
 

--- a/src/test/java/org/jboss/tm/usertx/JndiProvider.java
+++ b/src/test/java/org/jboss/tm/usertx/JndiProvider.java
@@ -1,6 +1,6 @@
 /*
    Copyright The Narayana Authors
-   SPDX short identifier: Apache-2.0
+   SPDX-License-Identifier: Apache-2.0
  */
 package org.jboss.tm.usertx;
 

--- a/src/test/java/org/jboss/tm/usertx/SPIUnitTest.java
+++ b/src/test/java/org/jboss/tm/usertx/SPIUnitTest.java
@@ -1,6 +1,6 @@
 /*
    Copyright The Narayana Authors
-   SPDX short identifier: Apache-2.0
+   SPDX-License-Identifier: Apache-2.0
  */
 package org.jboss.tm.usertx;
 

--- a/src/test/java/org/jboss/tm/usertx/TestUTSerializability.java
+++ b/src/test/java/org/jboss/tm/usertx/TestUTSerializability.java
@@ -1,6 +1,6 @@
 /*
    Copyright The Narayana Authors
-   SPDX short identifier: Apache-2.0
+   SPDX-License-Identifier: Apache-2.0
  */
 package org.jboss.tm.usertx;
 

--- a/src/test/java/org/jboss/tm/usertx/TxListener.java
+++ b/src/test/java/org/jboss/tm/usertx/TxListener.java
@@ -1,6 +1,6 @@
 /*
    Copyright The Narayana Authors
-   SPDX short identifier: Apache-2.0
+   SPDX-License-Identifier: Apache-2.0
  */
 package org.jboss.tm.usertx;
 


### PR DESCRIPTION
https://issues.redhat.com/browse/JBTM-3812

Replace "SPDX short identifier" with "SPDX-License-Identifier". Refer to https://spdx.dev/learn/handling-license-info/ for the details.